### PR TITLE
Fix git clone issue in github cloning

### DIFF
--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -44,6 +44,7 @@
     - name: install node-red from github
       git: repo=git://github.com/node-red/node-red.git
            accept_hostkey=yes
+           force=yes
            dest={{ install_path }}/node-red
 
     - name: install node-red from local checkout with npm
@@ -66,6 +67,7 @@
     - name: fetch node-red extra nodes from git
       git: repo=git://github.com/node-red/node-red-nodes.git
            accept_hostkey=yes
+           force=yes
            dest={{ install_path }}/node-red/node-red-nodes
 
     - name: install some extra nodes
@@ -92,11 +94,13 @@
     - name: install freeboard.io from git
       git: repo=git://github.com/Freeboard/freeboard.git
            accept_hostkey=yes
+           force=yes
            dest={{ install_path }}/freeboard
 
 #    - name: install freeboard.io plugins for websockets from git
 #      git: repo=git://github.com/Freeboard/plugins.git
 #           accept_hostkey=yes
+#           force=yes
 #           dest={{ install_path }}/freeboard-plugins
 
 #    - name: copy freeboard plugin to the right location


### PR DESCRIPTION
Vagrant 1.7.4
ansible 1.9.4

`vagrant up` gives the following output:

```
TASK: [quick workaround for npm modules expecting nodejs to be node] **********
changed: [default]

TASK: [install node-red from github] ******************************************
failed: [default] => {"failed": true}
msg: Local modifications exist in repository (force=no).

FATAL: all hosts have already failed -- aborting

PLAY RECAP ********************************************************************
           to retry, use: --limit @/Users/sdu/playbook.retry

default                    : ok=3    changed=2    unreachable=0    failed=1

Ansible failed to complete successfully. Any error output should be
visible above. Please fix these errors and try again.
```

I added a "force=yes" parameter to the ansible git tasks.
